### PR TITLE
Fixed triangleCount property of MeshGL

### DIFF
--- a/Sources/Manifold3D/MeshGL.swift
+++ b/Sources/Manifold3D/MeshGL.swift
@@ -44,7 +44,7 @@ public extension MeshGL {
     }
 
     var triangleCount: Int {
-        Int(meshGL.NumVert())
+        Int(meshGL.NumTri())
     }
 
     var tolerance: Double {


### PR DESCRIPTION
There was a typo: triangleCount returned vertex count instead of triangle count.