### PR TITLE
Expose MeshGL.merged() to recompute lost merge vectors

### DIFF
--- a/Sources/Manifold3D/MeshGL.swift
+++ b/Sources/Manifold3D/MeshGL.swift
@@ -27,6 +27,27 @@ public struct MeshGL<Vector: Vector3> {
 }
 
 public extension MeshGL {
+    /// Returns a copy whose merge vectors are recomputed so that topologically identical but
+    /// separated vertices are reconnected.
+    ///
+    /// This is a best-effort helper for the case where a manifold `MeshGL` was produced but its
+    /// merge vectors were lost through a round-trip via a file format (e.g. STL) that does not
+    /// preserve them. Manifoldness is judged by shared vertex *indices*, not by position, so a
+    /// surface that is closed geometrically but carries split coincident vertices is reported as
+    /// non-manifold — constructing a ``Manifold`` from it throws. Merging snaps those coincident
+    /// vertices back together so the mesh is accepted.
+    ///
+    /// When nothing needs merging, the result is equivalent to the original mesh.
+    ///
+    /// - Returns: A merged copy of the mesh.
+    func merged() -> MeshGL {
+        var meshGL = self.meshGL
+        _ = meshGL.Merge()
+        return MeshGL(meshGL: meshGL)
+    }
+}
+
+public extension MeshGL {
     /// The triangles of this mesh.
     var triangles: [Triangle] {
         let tris = Array(meshGL.triVerts)

--- a/Tests/Manifold3DTests/MeshGLMergeTests.swift
+++ b/Tests/Manifold3DTests/MeshGLMergeTests.swift
@@ -1,0 +1,39 @@
+import Testing
+@testable import Manifold3D
+
+// A closed tetrahedron whose corners are NOT shared by index: every face carries its own three
+// vertices (12 positions, 4 distinct corners). This is the shape a file-format round-trip (e.g. STL)
+// produces — geometrically closed, but non-manifold by index because no edge has a twin.
+private func splitTetrahedron() -> MeshGL<TestVec3> {
+    let a = TestVec3(x: 0, y: 0, z: 0)
+    let b = TestVec3(x: 1, y: 0, z: 0)
+    let c = TestVec3(x: 0, y: 1, z: 0)
+    let d = TestVec3(x: 0, y: 0, z: 1)
+    return MeshGL<TestVec3>(
+        vertices: [a, c, b,  a, b, d,  a, d, c,  b, c, d],
+        triangles: [Triangle(0, 1, 2), Triangle(3, 4, 5), Triangle(6, 7, 8), Triangle(9, 10, 11)]
+    )
+}
+
+@Test func `merged reconnects split vertices so a closed mesh is accepted`() throws {
+    let split = splitTetrahedron()
+
+    // Without merging the surface is closed but non-manifold by index, so construction fails.
+    let unmerged: TestManifold? = try? Manifold(split)
+    #expect(unmerged == nil)
+
+    // After merging, the coincident corners are reconnected and the mesh is accepted.
+    let solid: TestManifold = try Manifold(split.merged())
+    TestSupport.expectNoStatusError(solid)
+    #expect(!solid.isEmpty)
+    #expect(abs(solid.volume - 1.0 / 6.0) <= 1e-9)
+}
+
+@Test func `merged is a no-op for an already-connected mesh`() throws {
+    let cube: TestManifold = .cube(size: TestVec3(x: 1, y: 1, z: 1), center: true)
+    let mesh = cube.meshGL()
+
+    let remerged: TestManifold = try Manifold(mesh.merged())
+    TestSupport.expectNoStatusError(remerged)
+    #expect(abs(remerged.volume - cube.volume) <= 1e-9)
+}


### PR DESCRIPTION
## What

Exposes a Swift `MeshGL.merged()` that wraps the existing C++ `MeshGL::Merge()`. That helper is currently unreachable from the Swift API — `MeshGL` is constructed but its `Merge()` is never surfaced, and `Manifold.init(_:)` doesn't merge.

## Why

Manifold judges manifoldness by shared vertex **indices**, not position. A surface that is closed geometrically but carries split/unmerged coincident vertices therefore reports a non-manifold status, and `try Manifold(meshGL)` throws — even though the geometry is watertight.

This is exactly the case the C++ `Merge()` doc comment calls out: *"the case where a manifold MeshGL was produced, but its merge vectors were lost due to a round-trip through a file format."* It's the common situation when ingesting STL (and other formats that don't carry merge vectors): every triangle brings its own copies of shared corners. Today there's no way to recover from Swift without dropping to the C bindings.

`merged()` returns a copy with the merge vectors recomputed, so the mesh is accepted:

```swift
let solid = try Manifold(meshGLFromSTL.merged())
```

## API

```swift
public extension MeshGL {
    /// Returns a copy whose merge vectors are recomputed so that topologically identical but
    /// separated vertices are reconnected. No-op when nothing needs merging.
    func merged() -> MeshGL
}
```

Non-mutating (returns a copy), matching the immutable `MeshGL` value type. If you'd prefer a different shape — a mutating `@discardableResult func merge() -> Bool` mirroring the C++ return, or auto-merging inside `Manifold.init(_:)` — happy to adjust. I went with the least-invasive option that doesn't change existing construction behaviour.

## Tests

- A closed tetrahedron whose 4 corners are split across faces (12 vertices) is **rejected** by `Manifold(_:)` before `merged()` and **accepted** after, with the correct volume (1/6).
- `merged()` on an already-connected cube is a no-op (volume preserved).

Full suite green locally (81 tests, macOS).

## Context

Found while consuming manifold-swift from a mesh-reconstruction pipeline (ref #2). `slice`/`trim`/`projection`/properties all had Swift equivalents — `Merge()` was the only piece we still needed the raw C API for.
